### PR TITLE
Feature: generic upload & download

### DIFF
--- a/skynet.go
+++ b/skynet.go
@@ -23,12 +23,8 @@ type (
 		portalUploadPath             string
 		portalFileFieldname          string
 		portalDirectoryFileFieldname string
+		customFilename               string
 		dirname                      string
-	}
-
-	FileUploadOptions struct {
-		UploadOptions
-		customFilename string
 	}
 
 	// keys are filenames
@@ -40,14 +36,11 @@ type (
 )
 
 var (
-	DefaultUploadOptions = FileUploadOptions{
-		UploadOptions: UploadOptions{
-			portalUrl:                    "https://siasky.net",
-			portalUploadPath:             "/skynet/skyfile",
-			portalFileFieldname:          "file",
-			portalDirectoryFileFieldname: "files[]",
-		},
-		customFilename: "",
+	DefaultUploadOptions = UploadOptions{
+		portalUrl:                    "https://siasky.net",
+		portalUploadPath:             "/skynet/skyfile",
+		portalFileFieldname:          "file",
+		portalDirectoryFileFieldname: "files[]",
 	}
 
 	DefaultDownloadOptions = DownloadOptions{
@@ -119,7 +112,7 @@ func Upload(uploadData UploadData, opts UploadOptions) (string, error) {
 	return fmt.Sprintf("sia://%s", apiResponse.Skylink), nil
 }
 
-func UploadFile(path string, opts FileUploadOptions) (string, error) {
+func UploadFile(path string, opts UploadOptions) (string, error) {
 	// open the file
 	file, err := os.Open(path)
 	if err != nil {
@@ -138,10 +131,10 @@ func UploadFile(path string, opts FileUploadOptions) (string, error) {
 	uploadData := make(UploadData)
 	uploadData[filename] = file
 
-	return Upload(uploadData, opts.UploadOptions)
+	return Upload(uploadData, opts)
 }
 
-func UploadDirectory(path string, opts FileUploadOptions) (string, error) {
+func UploadDirectory(path string, opts UploadOptions) (string, error) {
 	// verify the given path is a directory
 	info, err := os.Stat(path)
 	if err != nil {
@@ -174,7 +167,7 @@ func UploadDirectory(path string, opts FileUploadOptions) (string, error) {
 		uploadData[fp] = file
 	}
 
-	return Upload(uploadData, opts.UploadOptions)
+	return Upload(uploadData, opts)
 }
 
 func Download(skylink string, opts DownloadOptions) (io.ReadCloser, error) {

--- a/skynet.go
+++ b/skynet.go
@@ -177,12 +177,21 @@ func UploadDirectory(path string, opts FileUploadOptions) (string, error) {
 	return Upload(uploadData, opts.UploadOptions)
 }
 
-func DownloadFile(path, skylink string, opts DownloadOptions) error {
+func Download(skylink string, opts DownloadOptions) (io.ReadCloser, error) {
 	resp, err := http.Get(fmt.Sprintf("%s/%s", strings.TrimRight(opts.portalUrl, "/"), strings.TrimPrefix(skylink, "sia://")))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+func DownloadFile(path, skylink string, opts DownloadOptions) error {
+	downloadData, err := Download(skylink, opts)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer downloadData.Close()
 
 	out, err := os.Create(path)
 	if err != nil {
@@ -190,7 +199,7 @@ func DownloadFile(path, skylink string, opts DownloadOptions) error {
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, resp.Body)
+	_, err = io.Copy(out, downloadData)
 	return err
 }
 

--- a/skynet.go
+++ b/skynet.go
@@ -205,20 +205,11 @@ func DownloadFile(path, skylink string, opts DownloadOptions) error {
 
 func walkDirectory(path string) ([]string, error) {
 	var files []string
-	err := filepath.Walk(path, func(subpath string, info os.FileInfo, err error) error {
+	err := filepath.Walk(path, func(path string, _ os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		fullpath := filepath.Join(path, subpath)
-		if info.IsDir() {
-			subfiles, err := walkDirectory(fullpath)
-			if err != nil {
-				return err
-			}
-			files = append(files, subfiles...)
-			return nil
-		}
-		files = append(files, fullpath)
+		files = append(files, path)
 		return nil
 	})
 	if err != nil {

--- a/skynet_test.go
+++ b/skynet_test.go
@@ -1,0 +1,53 @@
+package skynet
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWalkDirectory(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "testWalkDir")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	subDir, err := ioutil.TempDir(testDir, "subDir")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// lexical order to match filepath.Walk
+	testFiles := []string{
+		filepath.Join(testDir, "one"),
+		subDir,
+		filepath.Join(subDir, "foo"),
+		filepath.Join(testDir, "three"),
+		filepath.Join(testDir, "two"),
+	}
+
+	for i, f := range testFiles {
+		if i != 1 { // skip subDir which already exists
+			if err = ioutil.WriteFile(f, make([]byte, 0), 0666); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+
+	files, err := walkDirectory(testDir)
+	if err != nil {
+		t.Error(err)
+	}
+
+	testFiles = append([]string{testDir}, testFiles...)
+	if len(files) != len(testFiles) {
+		t.Errorf("length %d of walked files != length %d of testFiles", len(files), len(testFiles))
+	}
+	for i, f := range files {
+		if f != testFiles[i] {
+			t.Errorf("file %s at index %d != testFile %s at same index", f, i, testFiles[i])
+		}
+	}
+}


### PR DESCRIPTION
And I added a test for and fixed `walkDirectory` in e110ae8.

The core feature change in a2f97fe is to support uploading things from any `io.Reader` instead of requiring that they already live in files on the client.