### PR TITLE
Simplify options by removing `EncryptionOptions`

### DIFF
--- a/download.go
+++ b/download.go
@@ -16,7 +16,10 @@ type (
 	DownloadOptions struct {
 		Options
 
-		EncryptionOptions
+		// SkykeyName is the name of the skykey used to encrypt the upload.
+		SkykeyName string
+		// SkykeyID is the ID of the skykey used to encrypt the upload.
+		SkykeyID string
 	}
 )
 

--- a/encryption.go
+++ b/encryption.go
@@ -17,15 +17,6 @@ type (
 		Type   string `json:"type"`
 	}
 
-	// EncryptionOptions contains options used for encrypting uploads and
-	// decrypting downloads.
-	EncryptionOptions struct {
-		// SkykeyName is the name of the skykey used to encrypt the upload.
-		SkykeyName string
-		// SkykeyID is the ID of the skykey used to encrypt the upload.
-		SkykeyID string
-	}
-
 	// AddSkykeyOptions contains the options used for addskykey.
 	AddSkykeyOptions struct {
 		Options

--- a/upload.go
+++ b/upload.go
@@ -22,8 +22,6 @@ type (
 	UploadOptions struct {
 		Options
 
-		EncryptionOptions
-
 		// PortalFileFieldName is the fieldName for files on the portal.
 		PortalFileFieldName string
 		// PortalDirectoryFileFieldName is the fieldName for directory files on
@@ -38,6 +36,11 @@ type (
 		// the base name of the directory being uploaded will be used by
 		// default.
 		CustomDirname string
+
+		// SkykeyName is the name of the skykey used to encrypt the upload.
+		SkykeyName string
+		// SkykeyID is the ID of the skykey used to encrypt the upload.
+		SkykeyID string
 	}
 
 	// UploadResponse contains the response for uploads.

--- a/utils.go
+++ b/utils.go
@@ -25,11 +25,11 @@ type (
 	Options struct {
 		// PortalURL is the URL of the portal to use.
 		PortalURL string
-		// CustomUserAgent is the custom user agent to use.
-		CustomUserAgent string
 		// EndpointPath is the relative URL path of the portal endpoint to
 		// contact.
 		EndpointPath string
+		// CustomUserAgent is the custom user agent to use.
+		CustomUserAgent string
 	}
 )
 


### PR DESCRIPTION
This will make it easier to view available options and to document them in all
languages.